### PR TITLE
Fix Skill XP, Label and NextLevel when Adding or Deducting Skill XP

### DIFF
--- a/server/class/character.lua
+++ b/server/class/character.lua
@@ -270,16 +270,33 @@ function Character(data)
 
         if value < 0 then -- we are deducting exp
             -- check if we lower level
-            if newExp <= 0 and currentLevel > 1 then
-                self.skills[index].Level = currentLevel - 1
+            if newExp < 0 and currentLevel > 1 then
+                local levelsData = Config.Skills[index].Levels
+                local newLevel = currentLevel - 1
+                local expLoss = math.abs(value) -- Gives us how much XP was lost (as value would be negative when deducting XP)
+                local leftoverLoss = expLoss - oldExp
+                local prevLevelCap = levelsData[newLevel].NextLevel
+                local newExpInPrevLevel = prevLevelCap - leftoverLoss -- (Rollover the xp into previous level cap)
+
+                self.skills[index].Level = newLevel
+                self.skills[index].Exp = newExpInPrevLevel
+                self.skills[index].Label = levelsData[newLevel].Label
+                self.skills[index].NextLevel = levelsData[newLevel].NextLevel
+
                 TriggerClientEvent("vorp_core:Client:OnPlayerLevelUp", self.source, index, self.skills[index].Level, currentLevel)
                 TriggerEvent("vorp_core:Server:OnPlayerLevelUp", self.source, index, self.skills[index].Level, currentLevel)
             end
         else
             local nextLevelExp = self.skills[index].NextLevel
             if currentExp >= nextLevelExp then
-                self.skills[index].Level = currentLevel + 1
-                self.skills[index].Exp = 0
+                local levelsData = Config.Skills[index].Levels
+                local newLevel = currentLevel + 1
+
+                self.skills[index].Level = newLevel
+                self.skills[index].Exp = currentExp - nextLevelExp -- (Rollover the xp eg 102/100 will mean 2 xp into next level)
+                self.skills[index].Label = levelsData[newLevel].Label
+                self.skills[index].NextLevel = levelsData[newLevel].NextLevel
+                
                 TriggerClientEvent("vorp_core:Client:OnPlayerLevelUp", self.source, index, self.skills[index].Level, currentLevel)
                 TriggerEvent("vorp_core:Server:OnPlayerLevelUp", self.source, index, self.skills[index].Level, currentLevel)
             end


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
When adding or subtracting skill XP, the excess XP will now rollover.  i.e. Level 1 90/100 + 50xp = Level 2 40/200 or Level 3 46/300 - 50xp = Level 2 196/200.  This fix also changes the Label and NextLevel values correctly for the current skill level after adding/subtracting.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
As above.

### Explain the necessity of these changes and how they will impact the framework or its users.
This change fixes the Skills so that they can handle addition or subtraction of XP correctly.  Currently the Label and NextLevel values remain fixes as if the Player was Level 1, no matter which Level they actually are.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
explanation field
